### PR TITLE
Improving linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,8 +18,8 @@ module.exports = {
   ignorePatterns: ['.eslintrc.js'],
   rules: {
     '@typescript-eslint/interface-name-prefix': 'off',
-    '@typescript-eslint/explicit-function-return-type': 'off',
-    '@typescript-eslint/explicit-module-boundary-types': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/explicit-function-return-type': 'true',
+    '@typescript-eslint/explicit-module-boundary-types': 'true',
+    '@typescript-eslint/no-explicit-any': 'true',
   },
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": false,
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "strictBindCallApply": false,
     "forceConsistentCasingInFileNames": false,
     "noFallthroughCasesInSwitch": false


### PR DESCRIPTION
The auto-generated eslint configuration is not ideal so I decided to change it to force explicit types and, of course, no `any` is allowed.